### PR TITLE
fix: ignore small/zero-size windows

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -271,7 +271,7 @@ impl App {
     pub fn switch_windows(&mut self, hwnd: HWND, reverse: bool) -> Result<bool> {
         let windows = list_windows(self.config.switch_windows_ignore_minimal)?;
         debug!(
-            "switch windows hwnd:{hwnd:?} reverse:{reverse} {:?}",
+            "switch windows: hwnd:{hwnd:?} reverse:{reverse} state:{:?}",
             self.switch_windows_state
         );
         let module_path = match windows
@@ -348,7 +348,10 @@ impl App {
     }
 
     fn switch_apps(&mut self, reverse: bool) -> Result<()> {
-        debug!("switch apps reverse:{reverse} {:?}", self.switch_apps_state);
+        debug!(
+            "switch apps: reverse:{reverse}, state:{:?}",
+            self.switch_apps_state
+        );
         if let Some(state) = self.switch_apps_state.as_mut() {
             if reverse {
                 if state.index == 0 {
@@ -361,6 +364,7 @@ impl App {
             } else {
                 state.index += 1;
             };
+            debug!("switch apps: new index:{}", state.index);
             return Ok(());
         }
         let hwnd = self.hwnd;
@@ -381,10 +385,7 @@ impl App {
                     self.uwp_icons.insert(module_path.clone(), data);
                 }
             }
-            if module_hicon.is_none() {
-                module_hicon = get_module_icon(module_hwnd);
-            }
-            if let Some(hicon) = module_hicon {
+            if let Some(hicon) = module_hicon.or_else(|| get_module_icon(module_hwnd)) {
                 apps.push((hicon, module_hwnd));
             }
         }
@@ -448,6 +449,7 @@ impl App {
             index,
             icon_size,
         });
+        debug!("switch apps, new state:{:?}", self.switch_apps_state);
         Ok(())
     }
 

--- a/tools/inspect-windows/src/main.rs
+++ b/tools/inspect-windows/src/main.rs
@@ -14,18 +14,21 @@ fn main() -> Result<()> {
         let is_iconic = is_iconic_window(hwnd);
         let is_topmost = is_topmost_window(hwnd);
         let is_visible = is_visible_window(hwnd);
+        let (width, height) = get_window_size(hwnd);
         let owner_hwnd: HWND = unsafe { GetWindow(hwnd, GW_OWNER) };
         let owner_title = if owner_hwnd.0 > 0 {
             get_window_title(owner_hwnd)
         } else {
             "".into()
         };
+        let size = format!("{width}x{height}");
         println!(
-            "visible:{}cloacked{}iconic{}topmost:{} {}:{} {}:{}",
+            "visible:{}cloacked{}iconic{}topmost:{} {:>10} {:>10}:{} {}:{}",
             pretty_bool(is_visible),
             pretty_bool(is_cloaked),
             pretty_bool(is_iconic),
             pretty_bool(is_topmost),
+            size,
             hwnd.0,
             title,
             owner_hwnd.0,


### PR DESCRIPTION
Some windows (e.g. VSCode Upgrade Setup) is zero-size, they are invisible.

We have to filter out these small/zero-size windows.