### PR TITLE
better quality of module icon for non-uwp applications

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -4,9 +4,9 @@ use crate::keyboard::KeyboardListener;
 use crate::startup::Startup;
 use crate::trayicon::TrayIcon;
 use crate::utils::{
-    check_error, create_hicon_from_resource, get_foreground_window,
+    check_error, create_hicon_from_resource, get_foreground_window, get_module_icon_ex,
     get_uwp_icon_data, get_window_user_data, is_iconic_window, list_windows, set_foregound_window,
-    set_window_user_data, CheckError, get_module_icon_ex,
+    set_window_user_data, CheckError,
 };
 
 use anyhow::{anyhow, Result};

--- a/src/app.rs
+++ b/src/app.rs
@@ -4,9 +4,9 @@ use crate::keyboard::KeyboardListener;
 use crate::startup::Startup;
 use crate::trayicon::TrayIcon;
 use crate::utils::{
-    check_error, create_hicon_from_resource, get_foreground_window, get_module_icon,
+    check_error, create_hicon_from_resource, get_foreground_window,
     get_uwp_icon_data, get_window_user_data, is_iconic_window, list_windows, set_foregound_window,
-    set_window_user_data, CheckError,
+    set_window_user_data, CheckError, get_module_icon_ex,
 };
 
 use anyhow::{anyhow, Result};
@@ -385,7 +385,7 @@ impl App {
                     self.uwp_icons.insert(module_path.clone(), data);
                 }
             }
-            if let Some(hicon) = module_hicon.or_else(|| get_module_icon(module_hwnd)) {
+            if let Some(hicon) = module_hicon.or_else(|| get_module_icon_ex(module_path)) {
                 apps.push((hicon, module_hwnd));
             }
         }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,10 +1,12 @@
 mod check_error;
 mod single_instance;
 mod window;
+mod windows_icon;
 
 pub use check_error::*;
 pub use single_instance::*;
 pub use window::*;
+pub use windows_icon::get_module_icon_ex;
 
 pub fn to_wstring(value: &str) -> Vec<u16> {
     value.encode_utf16().chain(Some(0)).collect::<Vec<u16>>()

--- a/src/utils/windows_icon.rs
+++ b/src/utils/windows_icon.rs
@@ -1,0 +1,58 @@
+use std::{mem, time};
+
+use windows::{
+    core::PCWSTR,
+    Win32::{
+        Storage::FileSystem::FILE_ATTRIBUTE_NORMAL,
+        UI::{
+            Controls::IImageList,
+            Shell::{SHGetFileInfoW, SHGetImageList, SHFILEINFOW, SHGFI_SYSICONINDEX},
+            WindowsAndMessaging::HICON,
+        },
+    },
+};
+
+fn get_module_icon_ex0(ext: &str) -> Option<SHFILEINFOW> {
+    unsafe {
+        let mut p_path: Vec<u16> = ext.encode_utf16().chain(std::iter::once(0)).collect();
+        let mut file_info = SHFILEINFOW::default();
+        let file_info_size = mem::size_of_val(&file_info) as u32;
+        for _ in 0..3 {
+            // sporadically this method returns 0
+            let fff: usize = SHGetFileInfoW(
+                PCWSTR::from_raw(p_path.as_mut_ptr()),
+                FILE_ATTRIBUTE_NORMAL,
+                Some(&mut file_info),
+                file_info_size,
+                SHGFI_SYSICONINDEX,
+            );
+            if fff != 0 {
+                return Some(file_info);
+            } else {
+                let millis = time::Duration::from_millis(30);
+                std::thread::sleep(millis);
+            }
+        }
+        return None;
+    }
+}
+
+pub fn get_module_icon_ex(ext: &str) -> Option<HICON> {
+    unsafe {
+        let r: ::windows::core::Result<IImageList> = SHGetImageList(0x04);
+        match r {
+            ::windows::core::Result::Ok(list) => {
+                if let Some(icon) = get_module_icon_ex0(ext) {
+                    let r = list.GetIcon(icon.iIcon, 1u32);
+                    match r {
+                        Ok(v) => Some(v),
+                        Err(_) => None,
+                    }
+                } else {
+                    None
+                }
+            }
+            Err(_) => return None,
+        }
+    }
+}

--- a/src/utils/windows_icon.rs
+++ b/src/utils/windows_icon.rs
@@ -33,7 +33,7 @@ fn get_module_icon_ex0(ext: &str) -> Option<SHFILEINFOW> {
                 std::thread::sleep(millis);
             }
         }
-        return None;
+        None
     }
 }
 
@@ -52,7 +52,7 @@ pub fn get_module_icon_ex(ext: &str) -> Option<HICON> {
                     None
                 }
             }
-            Err(_) => return None,
+            Err(_) => None,
         }
     }
 }


### PR DESCRIPTION
Using executable's embed icon instead of window icon.

fixed
![after](https://github.com/sigoden/window-switcher/assets/34619326/da9c0fae-4e54-402e-939d-ae294785af79)

v1.2.1
![before](https://github.com/sigoden/window-switcher/assets/34619326/f5340651-fbbe-4bf4-8917-2b959bb022e5)

see also #70 #65 