### PR TITLE
List apps with higher perms, in non-administrator mode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ features = [
     "Win32_System_Registry",
     "Win32_System_Threading",
     "Win32_Storage_FileSystem",
+    "Win32_System_Diagnostics_ToolHelp"
 ]
 
 [build-dependencies]


### PR DESCRIPTION
List apps with higher perms when Switcher running in user mode.
For Example: Task Manager, WeGame, LOL (Tencent ver.)

Known issue: The icons of these apps have low resolution.