### PR TITLE
feat:  add `configure`  to tray menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ Tips: **Hold `Alt` and strike `Backtick/Tab` to cycle through, press `Alt + Back
 
 ## Configuration
 
-The window-switcher supports custom shortcuts, enabling and disabling certain functions, and all of these can be set through the configuration file.
+Window-Switcher offers various customization options to tailor its behavior to your preferences. You can define custom keyboard shortcuts, enable or disable specific features, and fine-tune settings through a configuration file.
 
-The configuration file must be named `window-switcher.ini` and located in the same directory as `window-switcher.exe` for the changes to take effect.  
+To personalize Window-Switcher, you'll need a configuration file named `window-switcher.ini`. This file should be placed in the same directory as the `window-switcher.exe` file. Once you've made changes to the configuration, make sure to restart Window-Switcher so your new settings can take effect.
 
 Here is the default configuration:
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,4 +1,4 @@
-use crate::config::Config;
+use crate::config::{open_config_file, Config};
 use crate::foreground::ForegroundWatcher;
 use crate::keyboard::KeyboardListener;
 use crate::startup::Startup;
@@ -40,6 +40,7 @@ pub const WM_USER_MODIFIER_KEYUP: u32 = 6001;
 pub const WM_USER_HOOTKEY: u32 = 6002;
 pub const IDM_EXIT: u32 = 1;
 pub const IDM_STARTUP: u32 = 2;
+pub const IDM_CONFIGURE: u32 = 3;
 
 pub fn start(config: &Config) -> Result<()> {
     info!("start config={:?}", config);
@@ -253,6 +254,11 @@ impl App {
                         IDM_STARTUP => {
                             let app = get_app(hwnd)?;
                             app.startup.toggle()?;
+                        }
+                        IDM_CONFIGURE => {
+                            if let Err(err) = open_config_file() {
+                                alert!("{err}");
+                            }
                         }
                         _ => {}
                     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,4 +1,4 @@
-use crate::config::{open_config_file, Config};
+use crate::config::{edit_config_file, Config};
 use crate::foreground::ForegroundWatcher;
 use crate::keyboard::KeyboardListener;
 use crate::startup::Startup;
@@ -256,7 +256,7 @@ impl App {
                             app.startup.toggle()?;
                         }
                         IDM_CONFIGURE => {
-                            if let Err(err) = open_config_file() {
+                            if let Err(err) = edit_config_file() {
                                 alert!("{err}");
                             }
                         }
@@ -280,7 +280,7 @@ impl App {
         Ok(unsafe { DefWindowProcW(hwnd, msg, wparam, lparam) })
     }
 
-    pub fn switch_windows(&mut self, hwnd: HWND, reverse: bool) -> Result<bool> {
+    fn switch_windows(&mut self, hwnd: HWND, reverse: bool) -> Result<bool> {
         let windows = list_windows(self.config.switch_windows_ignore_minimal)?;
         debug!(
             "switch windows: hwnd:{hwnd:?} reverse:{reverse} state:{:?}",

--- a/src/config.rs
+++ b/src/config.rs
@@ -280,12 +280,17 @@ pub(crate) fn open_config_file() -> Result<()> {
         .spawn()
         .map_err(|err| anyhow!("Failed to open config file '{}', {err}", filepath.display()))?
         .wait()
-        .map_err(|err| anyhow!("Failed to close config file '{}', {err}", filepath.display()))?;
+        .map_err(|err| {
+            anyhow!(
+                "Failed to close config file '{}', {err}",
+                filepath.display()
+            )
+        })?;
 
     if exit.success() {
         // restart
     }
-        
+
     Ok(())
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,7 +14,7 @@ pub const SWITCH_APPS_HOTKEY_ID: u32 = 2;
 
 const DEFAULT_CONFIG: &str = include_str!("../window-switcher.ini");
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Config {
     pub trayicon: bool,
     pub log_level: LevelFilter,
@@ -264,7 +264,7 @@ pub fn load_config() -> Result<Config> {
     Config::load(&conf)
 }
 
-pub(crate) fn open_config_file() -> Result<()> {
+pub(crate) fn edit_config_file() -> Result<bool> {
     let filepath = get_config_path()?;
     debug!("open config file '{}'", filepath.display());
     if !filepath.exists() {
@@ -287,11 +287,7 @@ pub(crate) fn open_config_file() -> Result<()> {
             )
         })?;
 
-    if exit.success() {
-        // restart
-    }
-
-    Ok(())
+    Ok(exit.success())
 }
 
 fn get_config_path() -> Result<PathBuf> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,4 +13,4 @@ mod startup;
 mod trayicon;
 
 pub use crate::app::start;
-pub use crate::config::{Config, load_config};
+pub use crate::config::{load_config, Config};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,4 +13,4 @@ mod startup;
 mod trayicon;
 
 pub use crate::app::start;
-pub use crate::config::Config;
+pub use crate::config::{Config, load_config};

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,12 +6,7 @@ use std::{
     path::Path,
 };
 
-use ini::Ini;
-use window_switcher::{
-    alert, start,
-    utils::{get_exe_folder, SingleInstance},
-    Config,
-};
+use window_switcher::{alert, load_config, start, utils::SingleInstance};
 
 fn main() {
     if let Err(err) = run() {
@@ -36,14 +31,6 @@ fn run() -> Result<()> {
         bail!("Another instance is running. This instance will abort.")
     }
     start(&config)
-}
-
-fn load_config() -> Result<Config> {
-    let folder = get_exe_folder()?;
-    let ini_file = folder.join("window-switcher.ini");
-    let conf =
-        Ini::load_from_file(ini_file).map_err(|err| anyhow!("Failed to load ini file, {err}"))?;
-    Config::load(&conf)
 }
 
 fn prepare_log_file(path: &Path) -> std::io::Result<File> {

--- a/src/trayicon.rs
+++ b/src/trayicon.rs
@@ -1,4 +1,4 @@
-use crate::app::{IDM_EXIT, IDM_STARTUP, IDM_CONFIGURE, NAME, WM_USER_TRAYICON};
+use crate::app::{IDM_CONFIGURE, IDM_EXIT, IDM_STARTUP, NAME, WM_USER_TRAYICON};
 
 use anyhow::{anyhow, Result};
 use windows::core::w;

--- a/src/trayicon.rs
+++ b/src/trayicon.rs
@@ -1,4 +1,4 @@
-use crate::app::{IDM_EXIT, IDM_STARTUP, NAME, WM_USER_TRAYICON};
+use crate::app::{IDM_EXIT, IDM_STARTUP, IDM_CONFIGURE, NAME, WM_USER_TRAYICON};
 
 use anyhow::{anyhow, Result};
 use windows::core::w;
@@ -14,6 +14,7 @@ use windows::Win32::UI::WindowsAndMessaging::{
 };
 
 const ICON_BYTES: &[u8] = include_bytes!("../assets/icon.ico");
+const TEXT_CONFIGURE: PCWSTR = w!("Configure");
 const TEXT_STARTUP: PCWSTR = w!("Startup");
 const TEXT_EXIT: PCWSTR = w!("Exit");
 
@@ -87,6 +88,7 @@ impl TrayIcon {
         let startup_flags = if startup { MF_CHECKED } else { MF_UNCHECKED };
         unsafe {
             let hmenu = CreatePopupMenu().map_err(|err| anyhow!("Failed to create menu, {err}"))?;
+            AppendMenuW(hmenu, MF_STRING, IDM_CONFIGURE as usize, TEXT_CONFIGURE)?;
             AppendMenuW(hmenu, startup_flags, IDM_STARTUP as usize, TEXT_STARTUP)?;
             AppendMenuW(hmenu, MF_STRING, IDM_EXIT as usize, TEXT_EXIT)?;
             Ok(hmenu)


### PR DESCRIPTION
 Adds a "Configure" option to the tray icon's context menu. Clicking it opens the "window-switcher.ini" configuration file using Notepad.