### PR TITLE
refactor: better set foreground

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ features = [
     "Win32_Graphics_GdiPlus",
     "Win32_Security",
     "Win32_Security_Authorization",
-    "Win32_System_Console",
     "Win32_System_LibraryLoader",
     "Win32_System_Registry",
     "Win32_System_SystemInformation",

--- a/src/utils/window.rs
+++ b/src/utils/window.rs
@@ -147,7 +147,7 @@ pub fn get_window_exe(hwnd: HWND) -> Option<String> {
         return None;
     }
     let module_path = get_module_path(pid)?;
-    module_path.split('\\').map(|v| v.to_string()).last()
+    module_path.split('\\').map(|v| v.to_string()).next_back()
 }
 
 pub fn set_foreground_window(hwnd: HWND) {


### PR DESCRIPTION
Instead of `AllocConsole`, we simulate an empty keyboard input. The purpose is to make this process the "most recently active input process" to obtain the permission to set the foreground window.