### PR TITLE
feat: support certain special permission apps like 1Password

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -48,6 +48,7 @@ static mut WM_TASKBARCREATED: u32 = 0;
 
 pub struct App {
     hwnd: HWND,
+    is_admin: bool,
     trayicon: Option<TrayIcon>,
     startup: Startup,
     config: Config,
@@ -77,6 +78,7 @@ impl App {
 
         let mut app = App {
             hwnd,
+            is_admin,
             trayicon,
             startup,
             config: config.clone(),
@@ -299,6 +301,7 @@ impl App {
         let windows = list_windows(
             self.config.switch_windows_ignore_minimal,
             self.config.switch_windows_only_current_desktop(),
+            self.is_admin,
         )?;
         debug!(
             "switch windows: hwnd:{hwnd:?} reverse:{reverse} state:{:?}",
@@ -400,6 +403,7 @@ impl App {
         let windows = list_windows(
             self.config.switch_apps_ignore_minimal,
             self.config.switch_apps_only_current_desktop(),
+            self.is_admin,
         )?;
         let mut apps = vec![];
         for (module_path, hwnds) in windows.iter() {

--- a/src/utils/admin.rs
+++ b/src/utils/admin.rs
@@ -2,25 +2,30 @@ use super::HandleWrapper;
 
 use anyhow::{anyhow, Result};
 use windows::Win32::{
+    Foundation::HANDLE,
     Security::{GetTokenInformation, TokenElevation, TOKEN_ELEVATION, TOKEN_QUERY},
-    System::Threading::{GetCurrentProcess, OpenProcessToken},
+    System::Threading::{
+        GetCurrentProcess, OpenProcess, OpenProcessToken, PROCESS_QUERY_LIMITED_INFORMATION,
+    },
 };
 
 pub fn is_running_as_admin() -> Result<bool> {
-    is_running_as_admin_impl()
+    let process = unsafe { GetCurrentProcess() };
+    is_elevated(process)
         .map_err(|err| anyhow!("Failed to verify if the program is running as admin, {err}"))
 }
 
-fn is_running_as_admin_impl() -> Result<bool> {
+pub fn is_process_elevated(pid: u32) -> Option<bool> {
+    let handle = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, None, pid) }.ok()?;
+    is_elevated(handle).ok()
+}
+
+pub fn is_elevated(handle: HANDLE) -> Result<bool> {
     let is_elevated = unsafe {
         let mut token_handle = HandleWrapper::default();
         let mut elevation = TOKEN_ELEVATION::default();
         let mut returned_length = 0;
-        OpenProcessToken(
-            GetCurrentProcess(),
-            TOKEN_QUERY,
-            token_handle.get_handle_mut(),
-        )?;
+        OpenProcessToken(handle, TOKEN_QUERY, token_handle.get_handle_mut())?;
 
         GetTokenInformation(
             token_handle.get_handle(),


### PR DESCRIPTION
After OpenProcess with PROCESS_QUERY_LIMITED_INFORMATION, window-switcher can access the exe path for certain special permission apps like 1Password.

```diff
-OpenProcess(PROCESS_QUERY_INFORMATION | PROCESS_VM_READ, None, pid)
+OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, None, pid)
```
close #181 