### PR TITLE
feat: ignore topmost windows

### DIFF
--- a/tools/inspect-windows/src/main.rs
+++ b/tools/inspect-windows/src/main.rs
@@ -12,7 +12,7 @@ fn main() -> Result<()> {
     for hwnd in hwnds {
         let title = get_window_title(hwnd);
         let cloak_type = get_window_cloak_type(hwnd);
-        let (is_visible, is_iconic, is_tool) = get_window_state(hwnd);
+        let (is_visible, is_iconic, is_tool, _is_topmost) = get_window_state(hwnd);
         let (width, height) = get_window_size(hwnd);
         let owner_hwnd: HWND = unsafe { GetWindow(hwnd, GW_OWNER) }.unwrap_or_default();
         let owner_title = if !owner_hwnd.is_invalid() {


### PR DESCRIPTION
In the windows obtained through enum_windows, the topmost one is listed first, This also resulted in the app icon being displayed at the forefront.

So we ignore the topmost window.