### PR TITLE
monitor-grouping feature

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+/shelf/
+/workspace.xml

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/window-switcher.iml" filepath="$PROJECT_DIR$/.idea/window-switcher.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/.idea/window-switcher.iml
+++ b/.idea/window-switcher.iml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="EMPTY_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ features = [
     "Win32_Graphics_GdiPlus",
     "Win32_Security",
     "Win32_Security_Authorization",
+    "Win32_System_Com",
     "Win32_System_LibraryLoader",
     "Win32_System_Registry",
     "Win32_System_SystemInformation",

--- a/src/app.rs
+++ b/src/app.rs
@@ -301,6 +301,7 @@ impl App {
         let windows = list_windows(
             self.config.switch_windows_ignore_minimal,
             self.config.switch_windows_only_current_desktop(),
+            self.config.switch_windows_only_current_monitor,
             self.is_admin,
         )?;
         debug!(
@@ -402,6 +403,7 @@ impl App {
         }
         let windows = list_windows(
             self.config.switch_apps_ignore_minimal,
+            self.config.switch_apps_only_current_monitor,
             self.config.switch_apps_only_current_desktop(),
             self.is_admin,
         )?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -22,16 +22,20 @@ pub struct Config {
     pub switch_windows_blacklist: HashSet<String>,
     pub switch_windows_ignore_minimal: bool,
     switch_windows_only_current_desktop: Option<bool>,
+    pub switch_windows_only_current_monitor: bool, // New field
     pub switch_apps_enable: bool,
     pub switch_apps_hotkey: Hotkey,
     pub switch_apps_ignore_minimal: bool,
     pub switch_apps_override_icons: IndexMap<String, String>,
     switch_apps_only_current_desktop: Option<bool>,
+    pub switch_apps_only_current_monitor: bool, // New field
 }
 
 impl Default for Config {
     fn default() -> Self {
         Self {
+            switch_windows_only_current_monitor: false, // Default to false
+            switch_apps_only_current_monitor: false,    // Default to false
             trayicon: true,
             log_level: LevelFilter::Info,
             log_file: None,
@@ -85,6 +89,12 @@ impl Config {
                     conf.switch_windows_hotkey =
                         Hotkey::create(SWITCH_WINDOWS_HOTKEY_ID, "switch windows", v)?;
                 }
+                if let Some(v) = section
+                    .get("only_current_monitor")
+                    .and_then(Config::to_bool)
+                {
+                    conf.switch_windows_only_current_monitor = v;
+                }
             }
 
             if let Some(v) = section
@@ -107,6 +117,12 @@ impl Config {
         if let Some(section) = ini_conf.section(Some("switch-apps")) {
             if let Some(v) = section.get("enable").and_then(Config::to_bool) {
                 conf.switch_apps_enable = v;
+            }
+            if let Some(v) = section
+                .get("only_current_monitor")
+                .and_then(Config::to_bool)
+            {
+                conf.switch_apps_only_current_monitor = v;
             }
             if let Some(v) = section.get("hotkey") {
                 if !v.trim().is_empty() {

--- a/src/painter.rs
+++ b/src/painter.rs
@@ -30,7 +30,7 @@ use windows::Win32::{
     },
 };
 
-pub const BG_DARK_COLOR: u32 = 0x4c4c4c;
+pub const BG_DARK_COLOR: u32 = 0x262626;
 pub const FG_DARK_COLOR: u32 = 0x3b3b3b;
 pub const BG_LIGHT_COLOR: u32 = 0xe0e0e0;
 pub const FG_LIGHT_COLOR: u32 = 0xf2f2f2;

--- a/src/utils/window.rs
+++ b/src/utils/window.rs
@@ -8,7 +8,7 @@ use windows::Win32::{
     Foundation::{HWND, LPARAM, MAX_PATH, POINT, RECT},
     Graphics::{
         Dwm::{DwmGetWindowAttribute, DWMWA_CLOAKED, DWM_CLOAKED_SHELL},
-        Gdi::{GetMonitorInfoW, MonitorFromPoint, MONITORINFO, MONITOR_DEFAULTTONEAREST},
+        Gdi::{GetMonitorInfoW, MonitorFromPoint, MonitorFromWindow, MONITORINFO, MONITOR_DEFAULTTONEAREST},
     },
     System::{
         LibraryLoader::GetModuleFileNameW,
@@ -203,14 +203,43 @@ pub fn set_window_user_data(hwnd: HWND, ptr: i32) -> i32 {
 pub fn set_window_user_data(hwnd: HWND, ptr: isize) -> isize {
     unsafe { windows::Win32::UI::WindowsAndMessaging::SetWindowLongPtrW(hwnd, GWL_USERDATA, ptr) }
 }
-
+pub fn get_window_monitor(hwnd: HWND) -> windows::Win32::Graphics::Gdi::HMONITOR {
+    unsafe { MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST) }
+}
+pub fn get_current_monitor() -> windows::Win32::Graphics::Gdi::HMONITOR {
+    unsafe {
+        let mut cursor = POINT::default();
+        let _ = GetCursorPos(&mut cursor);
+        MonitorFromPoint(cursor, MONITOR_DEFAULTTONEAREST)
+    }
+}
+pub fn is_window_on_current_monitor(hwnd: HWND) -> bool {
+    let window_monitor = get_window_monitor(hwnd);
+    let current_monitor = get_current_monitor();
+    window_monitor == current_monitor
+}
+pub fn get_monitor_bounds(hmonitor: windows::Win32::Graphics::Gdi::HMONITOR) -> Option<RECT> {
+    unsafe {
+        let mut mi = MONITORINFO {
+            cbSize: std::mem::size_of::<MONITORINFO>() as u32,
+            ..MONITORINFO::default()
+        };
+        let result = GetMonitorInfoW(hmonitor, &mut mi);
+        if result.as_bool() {
+            Some(mi.rcMonitor)
+        } else {
+            None
+        }
+    }
+}
 /// Lists available windows
 ///
-/// Duo to the limitation of `OpenProcess`, this function will not list `Task Manager`
+/// Due to the limitation of `OpenProcess`, this function will not list `Task Manager`
 /// and others which are running as administrator if `Switcher` is not `running as administrator`.
 pub fn list_windows(
     ignore_minimal: bool,
     only_current_desktop: bool,
+    only_current_monitor: bool,
     is_admin: bool,
 ) -> Result<IndexMap<String, Vec<(HWND, String)>>> {
     let mut result: IndexMap<String, Vec<(HWND, String)>> = IndexMap::new();
@@ -219,8 +248,15 @@ pub fn list_windows(
         .map_err(|e| anyhow!("Fail to get windows {}", e))?;
     let mut valid_hwnds = vec![];
     let mut owner_hwnds = vec![];
+    let current_monitor = if only_current_monitor {
+        Some(get_current_monitor())
+    } else {
+        None
+    };
+
     for hwnd in hwnds.iter().cloned() {
         let (is_visible, is_iconic, is_tool, is_topmost) = get_window_state(hwnd);
+
         let ok = is_visible
             && (if ignore_minimal { !is_iconic } else { true })
             && !is_tool
@@ -228,12 +264,20 @@ pub fn list_windows(
             && !is_cloaked_window(hwnd, only_current_desktop)
             && !is_small_window(hwnd);
         if ok {
+            //add monitor filtering
+            if let Some(monitor) = current_monitor {
+                let window_monitor = get_window_monitor(hwnd);
+                if window_monitor != monitor {
+                    owner_hwnds.push(get_owner_window(hwnd));
+                    continue; //skip this window if it's not on the current monitor
+                }
+            }
             let title = get_window_title(hwnd);
             if !title.is_empty() && title != "Windows Input Experience" {
                 valid_hwnds.push((hwnd, title));
             }
         }
-        owner_hwnds.push(get_owner_window(hwnd))
+        owner_hwnds.push(get_owner_window(hwnd));
     }
     for (hwnd, title) in valid_hwnds.into_iter() {
         let mut pid = get_window_pid(hwnd);


### PR DESCRIPTION
this feature allow you to separe apps and windows by monitors and desktops, you can use monitor grouping and virtual desktop at the same time for having the most independent app managment in your machine,
I updated the config file for you guys add this: 

`only_current_monitor = yes`
just this line enables this feature, in apps and windows

https://github.com/user-attachments/assets/9e4f50f0-4769-488b-b699-4dfb3351c13a

great tool, thanks :)


